### PR TITLE
Fix upload base directory and tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,18 +22,15 @@ Cree una base de datos llamada `aduana` y un usuario con las credenciales indica
 
 ## Configuración de la carpeta de cargas
 
-El servidor guarda archivos en la ruta indicada en `DocumentoAdjuntoService` y los sirve de forma estática:
+El servidor guarda archivos en la ruta definida por la propiedad `app.upload.base-dir` y los sirve de forma estática.
 
 ```
-private final String BASE_PATH = "C:/Users/ragal/IdeaProjects/sistema_aduanero/uploads";
-```
-
-```
-spring.web.resources.static-locations=file:///C:/Users/ragal/IdeaProjects/sistema_aduanero/uploads/
+app.upload.base-dir=backend/uploads
+spring.web.resources.static-locations=file:${app.upload.base-dir}/
 spring.mvc.static-path-pattern=/uploads/**
 ```
 
-Actualice estas rutas para que apunten a un directorio existente en su máquina y asegúrese de que la propiedad `spring.web.resources.static-locations` comience con `file:///`.
+Asegúrese de que la carpeta indicada exista antes de iniciar el servidor.
 
 ## Compilar y ejecutar el servidor
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -11,7 +11,7 @@ spring.jpa.show-sql=true
 spring.servlet.multipart.max-file-size=20MB
 spring.servlet.multipart.max-request-size=20MB
 
-app.upload.base-dir=uploads
+app.upload.base-dir=backend/uploads
 
 spring.web.resources.static-locations=file:${app.upload.base-dir}/
 spring.mvc.static-path-pattern=/uploads/**

--- a/backend/src/test/java/cl/duoc/sistema_aduanero/service/DocumentoAdjuntoServiceTest.java
+++ b/backend/src/test/java/cl/duoc/sistema_aduanero/service/DocumentoAdjuntoServiceTest.java
@@ -33,7 +33,7 @@ class DocumentoAdjuntoServiceTest {
   @BeforeEach
   void setUp() throws Exception {
     tempDir = Files.createTempDirectory("uploads");
-    ReflectionTestUtils.setField(service, "BASE_PATH", tempDir.toString());
+    ReflectionTestUtils.setField(service, "basePath", tempDir.toString());
   }
 
   @AfterEach


### PR DESCRIPTION
## Summary
- save uploads under `backend/uploads`
- document upload directory configuration in backend README
- align `DocumentoAdjuntoServiceTest` with new `basePath` field

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68454acc33f083268359c47c5d94e210