### PR TITLE
Show success alert after creating solicitud

### DIFF
--- a/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -6,8 +6,18 @@
   <div *ngIf="errorMsg" class="alert alert-danger">
     {{ errorMsg }}
   </div>
-  <div *ngIf="successMsg" class="alert alert-success">
+  <div
+    *ngIf="successMsg"
+    class="alert alert-success alert-dismissible fade show"
+    role="alert"
+  >
     {{ successMsg }}
+    <button
+      type="button"
+      class="btn-close"
+      aria-label="Close"
+      (click)="successMsg = ''"
+    ></button>
   </div>
 
   <form

--- a/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -221,7 +221,7 @@ export class FormularioSolicitudComponent implements OnInit {
       .crearConAdjunto(payload, tipos, archivos)
       .subscribe({
         next: () => {
-          this.successMsg = 'Solicitud enviada correctamente.';
+          this.successMsg = 'Solicitud creada con éxito.';
           this.errorMsg = '';
           setTimeout(() => this.router.navigate(['/solicitud-aduana']), 1500);
         },


### PR DESCRIPTION
## Summary
- improve success alert styling in the form page
- tweak success message wording

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*
- `./mvnw -q test` *(fails: network)*

------
https://chatgpt.com/codex/tasks/task_e_68455169a91c8326a6351de71d603b78