### PR TITLE
Improve success message flow

### DIFF
--- a/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -16,7 +16,7 @@
       type="button"
       class="btn-close"
       aria-label="Close"
-      (click)="successMsg = ''"
+      (click)="cerrarMensajeExito()"
     ></button>
   </div>
 

--- a/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -223,7 +223,6 @@ export class FormularioSolicitudComponent implements OnInit {
         next: () => {
           this.successMsg = 'Solicitud creada con éxito.';
           this.errorMsg = '';
-          setTimeout(() => this.router.navigate(['/solicitud-aduana']), 1500);
         },
         error: (err) => {
           console.error('Error al crear solicitud:', err);
@@ -305,6 +304,11 @@ export class FormularioSolicitudComponent implements OnInit {
       const first = document.querySelector('.ng-invalid') as HTMLElement;
       first?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }, 0);
+  }
+
+  cerrarMensajeExito(): void {
+    this.successMsg = '';
+    this.router.navigate(['/solicitud-aduana']);
   }
 
   cancelar(): void {


### PR DESCRIPTION
## Summary
- let the success alert stay visible until users close it
- when the success alert is closed, navigate back to the home page

## Testing
- `npm test --prefix frontend --silent -- --watch=false` *(fails: `ng: not found`)*
- `mvn -q -f backend/pom.xml test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684552e8ae608326a2ff0478ccc14b76