### PR TITLE
Add success modal overlay

### DIFF
--- a/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
+++ b/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.html
@@ -20,6 +20,20 @@
     ></button>
   </div>
 
+  <!-- Mensaje de éxito en modal -->
+  <div
+    class="modal-overlay"
+    *ngIf="successMsg"
+    tabindex="-1"
+  >
+    <div class="modal-box">
+      <p>{{ successMsg }}</p>
+      <button class="btn btn-primary" (click)="cerrarMensajeExito()">
+        Cerrar
+      </button>
+    </div>
+  </div>
+
   <form
     [formGroup]="formulario"
     (ngSubmit)="guardar()"

--- a/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.scss
+++ b/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.scss
@@ -16,3 +16,25 @@
   margin: 0;
   padding: 1rem 0;
 }
+
+// Estilos del modal de éxito
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1050;
+}
+
+.modal-box {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  max-width: 400px;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- show success message inside a modal overlay in `formulario-solicitud`
- style overlay and modal box in SCSS

## Testing
- `npm start` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684558705544832680776d7219b5d31c