### PR TITLE
Add solicitud listing endpoints

### DIFF
--- a/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -1,6 +1,8 @@
 package cl.duoc.sistema_aduanero.controller;
 
+import cl.duoc.sistema_aduanero.dto.AdjuntoViajeMenoresResponse;
 import cl.duoc.sistema_aduanero.dto.SolicitudViajeMenoresRequest;
+import cl.duoc.sistema_aduanero.dto.SolicitudViajeMenoresResponse;
 import cl.duoc.sistema_aduanero.model.AdjuntoViajeMenores;
 import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
 import cl.duoc.sistema_aduanero.service.DocumentoAdjuntoService;
@@ -92,9 +94,9 @@ public class SolicitudAduanaController {
     }
   }
 
-  @GetMapping("/descargar/{id}")
-  public ResponseEntity<InputStreamResource>
-  descargarTodosLosDocumentos(@PathVariable Long id) {
+  @GetMapping({"/descargar/{id}", "/{id}/adjuntos/zip"})
+  public ResponseEntity<InputStreamResource> descargarTodosLosDocumentos(
+      @PathVariable Long id) {
     try {
       Optional<SolicitudViajeMenores> solicitudOpt =
           solicitudService.obtenerPorId(id);
@@ -149,6 +151,63 @@ public class SolicitudAduanaController {
       e.printStackTrace();
       return ResponseEntity.internalServerError().build();
     }
+  }
+
+  @GetMapping
+  public ResponseEntity<List<SolicitudViajeMenoresResponse>> obtenerTodas() {
+    List<SolicitudViajeMenores> solicitudes =
+        solicitudService.obtenerTodasConDocumentos();
+    List<SolicitudViajeMenoresResponse> respuesta =
+        solicitudes.stream().map(this::mapearSolicitud).toList();
+    return ResponseEntity.ok(respuesta);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<SolicitudViajeMenoresResponse> obtenerPorId(
+      @PathVariable Long id) {
+    Optional<SolicitudViajeMenores> opt =
+        solicitudService.obtenerPorIdConDocumentos(id);
+    if (opt.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+    return ResponseEntity.ok(mapearSolicitud(opt.get()));
+  }
+
+  private SolicitudViajeMenoresResponse mapearSolicitud(SolicitudViajeMenores s) {
+    SolicitudViajeMenoresResponse r = new SolicitudViajeMenoresResponse();
+    r.setId(s.getId());
+    r.setEstado(s.getEstado());
+    r.setFechaCreacion(s.getFechaCreacion());
+    r.setTipoSolicitudMenor(s.getTipoSolicitudMenor());
+    r.setNombreMenor(s.getNombreMenor());
+    r.setFechaNacimientoMenor(s.getFechaNacimientoMenor());
+    r.setDocumentoMenor(s.getDocumentoMenor());
+    r.setNumeroDocumentoMenor(s.getNumeroDocumentoMenor());
+    r.setNacionalidadMenor(s.getNacionalidadMenor());
+    r.setNombrePadreMadre(s.getNombrePadreMadre());
+    r.setRelacionMenor(s.getRelacionMenor());
+    r.setDocumentoPadre(s.getDocumentoPadre());
+    r.setNumeroDocumentoPadre(s.getNumeroDocumentoPadre());
+    r.setTelefonoPadre(s.getTelefonoPadre());
+    r.setEmailPadre(s.getEmailPadre());
+    r.setFechaViaje(s.getFechaViaje());
+    r.setNumeroTransporte(s.getNumeroTransporte());
+    r.setPaisOrigen(s.getPaisOrigen());
+    r.setPaisDestino(s.getPaisDestino());
+    r.setMotivoViaje(s.getMotivoViaje());
+    List<AdjuntoViajeMenoresResponse> docs =
+        s.getDocumentos().stream().map(this::mapearAdjunto).toList();
+    r.setDocumentos(docs);
+    return r;
+  }
+
+  private AdjuntoViajeMenoresResponse mapearAdjunto(AdjuntoViajeMenores a) {
+    AdjuntoViajeMenoresResponse r = new AdjuntoViajeMenoresResponse();
+    r.setId(a.getId());
+    r.setNombreOriginal(a.getNombreOriginal());
+    r.setNombreArchivo(a.getNombreArchivo());
+    r.setRuta(a.getRuta());
+    return r;
   }
 
 }

--- a/backend/src/main/java/cl/duoc/sistema_aduanero/repository/SolicitudAduanaRepository.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/repository/SolicitudAduanaRepository.java
@@ -1,7 +1,19 @@
 package cl.duoc.sistema_aduanero.repository;
 
 import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SolicitudAduanaRepository
-    extends JpaRepository<SolicitudViajeMenores, Long> {}
+    extends JpaRepository<SolicitudViajeMenores, Long> {
+
+  @Query("SELECT DISTINCT s FROM SolicitudViajeMenores s LEFT JOIN FETCH s.documentos")
+  List<SolicitudViajeMenores> findAllWithDocumentos();
+
+  @Query(
+      "SELECT s FROM SolicitudViajeMenores s LEFT JOIN FETCH s.documentos WHERE s.id = :id")
+  Optional<SolicitudViajeMenores> findByIdWithDocumentos(@Param("id") Long id);
+}

--- a/backend/src/main/java/cl/duoc/sistema_aduanero/service/SolicitudAduanaService.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/service/SolicitudAduanaService.java
@@ -23,6 +23,10 @@ public class SolicitudAduanaService {
     return repository.findAll();
   }
 
+  public List<SolicitudViajeMenores> obtenerTodasConDocumentos() {
+    return repository.findAllWithDocumentos();
+  }
+
   public SolicitudViajeMenores actualizarEstado(Long id, String nuevoEstado) {
     SolicitudViajeMenores solicitud = repository.findById(id).orElseThrow(
         () -> new RuntimeException("Solicitud no encontrada"));
@@ -32,5 +36,9 @@ public class SolicitudAduanaService {
 
   public Optional<SolicitudViajeMenores> obtenerPorId(Long id) {
     return repository.findById(id);
+  }
+
+  public Optional<SolicitudViajeMenores> obtenerPorIdConDocumentos(Long id) {
+    return repository.findByIdWithDocumentos(id);
   }
 }


### PR DESCRIPTION
## Summary
- provide repository methods for fetching solicitudes with attachments
- expose service methods with attachments
- add REST endpoints to list all solicitudes and get details by ID
- support downloading attachments using old or new path

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68455cf80be48326974037bf6dec7cd1