### PR TITLE
Add status update endpoint

### DIFF
--- a/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -173,6 +173,17 @@ public class SolicitudAduanaController {
     return ResponseEntity.ok(mapearSolicitud(opt.get()));
   }
 
+  @PutMapping("/{id}/estado")
+  public ResponseEntity<Void> actualizarEstado(
+      @PathVariable Long id, @RequestParam String estado) {
+    try {
+      solicitudService.actualizarEstado(id, estado);
+      return ResponseEntity.ok().build();
+    } catch (RuntimeException ex) {
+      return ResponseEntity.notFound().build();
+    }
+  }
+
   private SolicitudViajeMenoresResponse mapearSolicitud(SolicitudViajeMenores s) {
     SolicitudViajeMenoresResponse r = new SolicitudViajeMenoresResponse();
     r.setId(s.getId());

--- a/backend/src/main/java/cl/duoc/sistema_aduanero/javafx/MainController.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/javafx/MainController.java
@@ -215,7 +215,7 @@ public class MainController {
       showAlert(Alert.AlertType.WARNING, "Selecciona una solicitud primero.");
       return;
     }
-    cambiarEstado(sel.getId(), "APROBADA");
+    cambiarEstado(sel.getId(), "APROBADO");
   }
 
   // ======================
@@ -229,7 +229,7 @@ public class MainController {
       showAlert(Alert.AlertType.WARNING, "Selecciona una solicitud primero.");
       return;
     }
-    cambiarEstado(sel.getId(), "RECHAZADA");
+    cambiarEstado(sel.getId(), "RECHAZADO");
   }
 
   // ======================

--- a/backend/src/main/java/cl/duoc/sistema_aduanero/model/EstadoSolicitud.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/model/EstadoSolicitud.java
@@ -1,0 +1,7 @@
+package cl.duoc.sistema_aduanero.model;
+
+public enum EstadoSolicitud {
+  PENDIENTE,
+  APROBADO,
+  RECHAZADO
+}

--- a/backend/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
+++ b/backend/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
@@ -120,4 +120,21 @@ class SolicitudAduanaControllerTest {
     verify(solicitudService).crearSolicitud(captor.capture());
     assertEquals("Chile", captor.getValue().getPaisOrigen());
   }
+
+  @Test
+  void cambiarEstado() throws Exception {
+    SolicitudViajeMenores solicitud = new SolicitudViajeMenores();
+    solicitud.setId(7L);
+
+    Mockito
+        .when(solicitudService.actualizarEstado(7L, "APROBADO"))
+        .thenReturn(solicitud);
+
+    mockMvc
+        .perform(put("/api/solicitudes/7/estado")
+                     .param("estado", "APROBADO"))
+        .andExpect(status().isOk());
+
+    verify(solicitudService).actualizarEstado(7L, "APROBADO");
+  }
 }


### PR DESCRIPTION
## Summary
- create `EstadoSolicitud` enum
- allow UI to send `APROBADO` and `RECHAZADO`
- expose `PUT /api/solicitudes/{id}/estado`
- test controller for new endpoint

## Testing
- `mvn -q test` *(fails: mvn not found / network)*

------
https://chatgpt.com/codex/tasks/task_e_6845e62d542c8326b9e95fc91f30b675