### PR TITLE
Add basic accessibility menu

### DIFF
--- a/frontend/src/app/pages/inicio/inicio.html
+++ b/frontend/src/app/pages/inicio/inicio.html
@@ -4,3 +4,23 @@
     <span class="me-2">🧒✈️</span> Solicitud Viaje de Menor
   </a>
 </div>
+
+<button
+  class="btn btn-secondary accessibility-btn"
+  type="button"
+  (click)="toggleAccessibilityMenu()"
+>
+  Accesibilidad
+</button>
+
+<div *ngIf="showAccessibilityMenu" class="card accessibility-menu">
+  <div class="card-body">
+    <h5 class="card-title">Opciones de Accesibilidad</h5>
+    <ul class="list-unstyled mb-0">
+      <li><button class="btn btn-link p-0">Aumentar tamaño de texto</button></li>
+      <li><button class="btn btn-link p-0">Contraste alto</button></li>
+      <li><button class="btn btn-link p-0">Leer en voz alta</button></li>
+      <li><button class="btn btn-link p-0">Navegación por teclado</button></li>
+    </ul>
+  </div>
+</div>

--- a/frontend/src/app/pages/inicio/inicio.scss
+++ b/frontend/src/app/pages/inicio/inicio.scss
@@ -7,3 +7,18 @@
   font-size: 1.5rem;
   padding: 2rem 3rem;
 }
+
+.accessibility-btn {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 1050;
+}
+
+.accessibility-menu {
+  position: fixed;
+  bottom: 4rem;
+  right: 1rem;
+  width: 250px;
+  z-index: 1050;
+}

--- a/frontend/src/app/pages/inicio/inicio.ts
+++ b/frontend/src/app/pages/inicio/inicio.ts
@@ -9,4 +9,10 @@ import { CommonModule } from '@angular/common';
   templateUrl: './inicio.html',
   styleUrls: ['./inicio.scss']
 })
-export class InicioComponent {}
+export class InicioComponent {
+  protected showAccessibilityMenu = false;
+
+  protected toggleAccessibilityMenu(): void {
+    this.showAccessibilityMenu = !this.showAccessibilityMenu;
+  }
+}


### PR DESCRIPTION
## Summary
- add an accessibility button to the home page that toggles a simple menu
- implement menu toggle logic in `InicioComponent`
- add styles for floating button and menu

## Testing
- `npm test --prefix frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846012376f4832696781ed41374f1fd