### PR TITLE
Add endpoints to list and fetch solicitud

### DIFF
--- a/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -1,6 +1,8 @@
 package cl.duoc.sistema_aduanero.controller;
 
+import cl.duoc.sistema_aduanero.dto.AdjuntoViajeMenoresResponse;
 import cl.duoc.sistema_aduanero.dto.SolicitudViajeMenoresRequest;
+import cl.duoc.sistema_aduanero.dto.SolicitudViajeMenoresResponse;
 import cl.duoc.sistema_aduanero.model.AdjuntoViajeMenores;
 import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
 import cl.duoc.sistema_aduanero.service.DocumentoAdjuntoService;
@@ -149,6 +151,63 @@ public class SolicitudAduanaController {
       e.printStackTrace();
       return ResponseEntity.internalServerError().build();
     }
+  }
+
+  @GetMapping
+  public ResponseEntity<List<SolicitudViajeMenoresResponse>> obtenerTodas() {
+    List<SolicitudViajeMenores> solicitudes =
+        solicitudService.obtenerTodasConDocumentos();
+    List<SolicitudViajeMenoresResponse> respuesta =
+        solicitudes.stream().map(this::mapearSolicitud).toList();
+    return ResponseEntity.ok(respuesta);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<SolicitudViajeMenoresResponse> obtenerPorId(
+      @PathVariable Long id) {
+    Optional<SolicitudViajeMenores> opt =
+        solicitudService.obtenerPorIdConDocumentos(id);
+    if (opt.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+    return ResponseEntity.ok(mapearSolicitud(opt.get()));
+  }
+
+  private SolicitudViajeMenoresResponse mapearSolicitud(SolicitudViajeMenores s) {
+    SolicitudViajeMenoresResponse r = new SolicitudViajeMenoresResponse();
+    r.setId(s.getId());
+    r.setEstado(s.getEstado());
+    r.setFechaCreacion(s.getFechaCreacion());
+    r.setTipoSolicitudMenor(s.getTipoSolicitudMenor());
+    r.setNombreMenor(s.getNombreMenor());
+    r.setFechaNacimientoMenor(s.getFechaNacimientoMenor());
+    r.setDocumentoMenor(s.getDocumentoMenor());
+    r.setNumeroDocumentoMenor(s.getNumeroDocumentoMenor());
+    r.setNacionalidadMenor(s.getNacionalidadMenor());
+    r.setNombrePadreMadre(s.getNombrePadreMadre());
+    r.setRelacionMenor(s.getRelacionMenor());
+    r.setDocumentoPadre(s.getDocumentoPadre());
+    r.setNumeroDocumentoPadre(s.getNumeroDocumentoPadre());
+    r.setTelefonoPadre(s.getTelefonoPadre());
+    r.setEmailPadre(s.getEmailPadre());
+    r.setFechaViaje(s.getFechaViaje());
+    r.setNumeroTransporte(s.getNumeroTransporte());
+    r.setPaisOrigen(s.getPaisOrigen());
+    r.setPaisDestino(s.getPaisDestino());
+    r.setMotivoViaje(s.getMotivoViaje());
+    List<AdjuntoViajeMenoresResponse> docs =
+        s.getDocumentos().stream().map(this::mapearAdjunto).toList();
+    r.setDocumentos(docs);
+    return r;
+  }
+
+  private AdjuntoViajeMenoresResponse mapearAdjunto(AdjuntoViajeMenores a) {
+    AdjuntoViajeMenoresResponse r = new AdjuntoViajeMenoresResponse();
+    r.setId(a.getId());
+    r.setNombreOriginal(a.getNombreOriginal());
+    r.setNombreArchivo(a.getNombreArchivo());
+    r.setRuta(a.getRuta());
+    return r;
   }
 
 }


### PR DESCRIPTION
## Summary
- implement GET `/api/solicitudes` and `/api/solicitudes/{id}`
- add mapping helpers for `SolicitudViajeMenoresResponse`

## Testing
- `mvn test` *(fails: maven unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684603bf50208326b0cd5a3af58c08f3