### PR TITLE
Add tracking page and endpoint

### DIFF
--- a/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -3,6 +3,7 @@ package cl.duoc.sistema_aduanero.controller;
 import cl.duoc.sistema_aduanero.dto.AdjuntoViajeMenoresResponse;
 import cl.duoc.sistema_aduanero.dto.SolicitudViajeMenoresRequest;
 import cl.duoc.sistema_aduanero.dto.SolicitudViajeMenoresResponse;
+import cl.duoc.sistema_aduanero.dto.SolicitudSeguimientoResponse;
 import cl.duoc.sistema_aduanero.model.AdjuntoViajeMenores;
 import cl.duoc.sistema_aduanero.model.SolicitudViajeMenores;
 import cl.duoc.sistema_aduanero.model.EstadoSolicitud;
@@ -163,6 +164,16 @@ public class SolicitudAduanaController {
     return ResponseEntity.ok(respuesta);
   }
 
+  @GetMapping("/menor")
+  public ResponseEntity<List<SolicitudSeguimientoResponse>> obtenerPorRutMenor(
+      @RequestParam String rut) {
+    List<SolicitudViajeMenores> solicitudes =
+        solicitudService.obtenerPorRutMenor(rut);
+    List<SolicitudSeguimientoResponse> respuesta =
+        solicitudes.stream().map(this::mapearSeguimiento).toList();
+    return ResponseEntity.ok(respuesta);
+  }
+
   @GetMapping("/{id}")
   public ResponseEntity<SolicitudViajeMenoresResponse> obtenerPorId(
       @PathVariable Long id) {
@@ -212,6 +223,15 @@ public class SolicitudAduanaController {
     List<AdjuntoViajeMenoresResponse> docs =
         s.getDocumentos().stream().map(this::mapearAdjunto).toList();
     r.setDocumentos(docs);
+    return r;
+  }
+
+  private SolicitudSeguimientoResponse mapearSeguimiento(SolicitudViajeMenores s) {
+    SolicitudSeguimientoResponse r = new SolicitudSeguimientoResponse();
+    r.setId(s.getId());
+    r.setFechaCreacion(s.getFechaCreacion());
+    r.setNumeroDocumentoMenor(s.getNumeroDocumentoMenor());
+    r.setEstado(s.getEstado());
     return r;
   }
 

--- a/backend/src/main/java/cl/duoc/sistema_aduanero/dto/SolicitudSeguimientoResponse.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/dto/SolicitudSeguimientoResponse.java
@@ -1,0 +1,42 @@
+package cl.duoc.sistema_aduanero.dto;
+
+import java.time.LocalDateTime;
+
+public class SolicitudSeguimientoResponse {
+  private Long id;
+  private LocalDateTime fechaCreacion;
+  private String numeroDocumentoMenor;
+  private String estado;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public LocalDateTime getFechaCreacion() {
+    return fechaCreacion;
+  }
+
+  public void setFechaCreacion(LocalDateTime fechaCreacion) {
+    this.fechaCreacion = fechaCreacion;
+  }
+
+  public String getNumeroDocumentoMenor() {
+    return numeroDocumentoMenor;
+  }
+
+  public void setNumeroDocumentoMenor(String numeroDocumentoMenor) {
+    this.numeroDocumentoMenor = numeroDocumentoMenor;
+  }
+
+  public String getEstado() {
+    return estado;
+  }
+
+  public void setEstado(String estado) {
+    this.estado = estado;
+  }
+}

--- a/backend/src/main/java/cl/duoc/sistema_aduanero/repository/SolicitudAduanaRepository.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/repository/SolicitudAduanaRepository.java
@@ -16,4 +16,6 @@ public interface SolicitudAduanaRepository
   @Query(
       "SELECT s FROM SolicitudViajeMenores s LEFT JOIN FETCH s.documentos WHERE s.id = :id")
   Optional<SolicitudViajeMenores> findByIdWithDocumentos(@Param("id") Long id);
+
+  List<SolicitudViajeMenores> findByNumeroDocumentoMenor(String numeroDocumentoMenor);
 }

--- a/backend/src/main/java/cl/duoc/sistema_aduanero/service/SolicitudAduanaService.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/service/SolicitudAduanaService.java
@@ -41,4 +41,8 @@ public class SolicitudAduanaService {
   public Optional<SolicitudViajeMenores> obtenerPorIdConDocumentos(Long id) {
     return repository.findByIdWithDocumentos(id);
   }
+
+  public List<SolicitudViajeMenores> obtenerPorRutMenor(String rut) {
+    return repository.findByNumeroDocumentoMenor(rut);
+  }
 }

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { Routes } from '@angular/router';
 // Importamos solo los componentes que realmente tenemos en este momento:
 import { FormularioSolicitudComponent } from './pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud';
 import { InicioComponent } from './pages/inicio/inicio';
+import { SeguimientoComponent } from './pages/seguimiento/seguimiento';
 
 /**
  * Nota: Hemos comentado (o eliminado) las rutas de listado y detalle 
@@ -18,6 +19,9 @@ export const routes: Routes = [
 
   // Ruta para crear nueva solicitud
   { path: 'solicitud/nuevo/viaje-menor', component: FormularioSolicitudComponent },
+
+  // Seguimiento de solicitudes por RUT
+  { path: 'seguimiento', component: SeguimientoComponent },
 
   // 3) Editar una solicitud (usa el mismo componente de formulario)
   { path: 'solicitud-aduana/editar/:id', component: FormularioSolicitudComponent },

--- a/frontend/src/app/pages/inicio/inicio.html
+++ b/frontend/src/app/pages/inicio/inicio.html
@@ -3,6 +3,9 @@
   <a routerLink="/solicitud/nuevo/viaje-menor" class="btn btn-primary solicitud-btn">
     <span class="me-2">🧒✈️</span> Solicitud Viaje de Menor
   </a>
+  <a routerLink="/seguimiento" class="btn btn-outline-primary solicitud-btn ms-2">
+    Seguimiento
+  </a>
 </div>
 
 <button

--- a/frontend/src/app/pages/seguimiento/seguimiento.html
+++ b/frontend/src/app/pages/seguimiento/seguimiento.html
@@ -1,0 +1,35 @@
+<div class="container">
+  <h2 class="mb-4">Seguimiento de Solicitudes</h2>
+  <form (ngSubmit)="buscar()" class="mb-3">
+    <div class="input-group">
+      <input
+        type="text"
+        class="form-control"
+        placeholder="RUT del menor"
+        name="rut"
+        [(ngModel)]="rut"
+        required
+      />
+      <button class="btn btn-primary" type="submit">Buscar</button>
+    </div>
+  </form>
+  <div *ngIf="errorMsg" class="alert alert-danger">{{ errorMsg }}</div>
+  <table *ngIf="resultados.length" class="table">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Fecha</th>
+        <th>RUT</th>
+        <th>Estado</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let s of resultados">
+        <td>{{ s.id }}</td>
+        <td>{{ s.fechaCreacion | date: 'short' }}</td>
+        <td>{{ s.numeroDocumentoMenor }}</td>
+        <td>{{ s.estado }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/frontend/src/app/pages/seguimiento/seguimiento.scss
+++ b/frontend/src/app/pages/seguimiento/seguimiento.scss
@@ -1,0 +1,3 @@
+.container {
+  margin-top: 2rem;
+}

--- a/frontend/src/app/pages/seguimiento/seguimiento.ts
+++ b/frontend/src/app/pages/seguimiento/seguimiento.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { SolicitudAduanaService } from '../../services/solicitudes-aduana/solicitud-aduana';
+import { SolicitudViajeMenor } from '../../models/solicitud-viaje-menor';
+
+@Component({
+  selector: 'app-seguimiento',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './seguimiento.html',
+  styleUrls: ['./seguimiento.scss'],
+})
+export class SeguimientoComponent {
+  protected rut = '';
+  protected resultados: SolicitudViajeMenor[] = [];
+  protected errorMsg = '';
+
+  constructor(private servicio: SolicitudAduanaService) {}
+
+  protected buscar(): void {
+    this.errorMsg = '';
+    this.servicio.obtenerPorRutMenor(this.rut).subscribe({
+      next: (data) => (this.resultados = data),
+      error: () => (this.errorMsg = 'No se pudo obtener la información'),
+    });
+  }
+}

--- a/frontend/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/frontend/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -46,4 +46,9 @@ export class SolicitudAduanaService {
 
     return this.http.post<SolicitudViajeMenor>(this.baseUrl, formData);
   }
+
+  obtenerPorRutMenor(rut: string): Observable<SolicitudViajeMenor[]> {
+    const params = new HttpParams().set('rut', rut);
+    return this.http.get<SolicitudViajeMenor[]>(`${this.baseUrl}/menor`, { params });
+  }
 }


### PR DESCRIPTION
## Summary
- add backend endpoint to fetch requests by minor's RUT
- expose minimal `SolicitudSeguimientoResponse` DTO
- extend Angular service and routes
- create Seguimiento page
- add Seguimiento button on home page

## Testing
- `./mvnw -q -DskipTests package` *(fails: network access needed)*
- `./mvnw -q test` *(fails: network access needed)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe874d6083268567dc7f5214e118