### PR TITLE
Fix route for seguimiento endpoint

### DIFF
--- a/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -174,7 +174,7 @@ public class SolicitudAduanaController {
     return ResponseEntity.ok(respuesta);
   }
 
-  @GetMapping("/{id}")
+  @GetMapping("/{id:\\d+}")
   public ResponseEntity<SolicitudViajeMenoresResponse> obtenerPorId(
       @PathVariable Long id) {
     Optional<SolicitudViajeMenores> opt =


### PR DESCRIPTION
## Summary
- restrict `/api/solicitudes/{id}` route so it only matches numeric IDs

## Testing
- `./mvnw -q test` *(fails: no internet access to download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e02304a18832696193b8eb35f0748