### PR TITLE
Change tracking search to use ID

### DIFF
--- a/frontend/src/app/pages/seguimiento/seguimiento.html
+++ b/frontend/src/app/pages/seguimiento/seguimiento.html
@@ -5,10 +5,9 @@
       <input
         type="text"
         class="form-control"
-        placeholder="RUT del menor"
-        name="rut"
-        [(ngModel)]="rut"
-        (input)="formatearRut($event)"
+        placeholder="ID de la solicitud"
+        name="id"
+        [(ngModel)]="id"
         required
       />
       <button class="btn btn-primary" type="submit">Buscar</button>

--- a/frontend/src/app/pages/seguimiento/seguimiento.ts
+++ b/frontend/src/app/pages/seguimiento/seguimiento.ts
@@ -12,69 +12,32 @@ import { SolicitudViajeMenor } from '../../models/solicitud-viaje-menor';
   styleUrls: ['./seguimiento.scss'],
 })
 export class SeguimientoComponent {
-  protected rut = '';
+  protected id = '';
   protected resultados: SolicitudViajeMenor[] = [];
   protected errorMsg = '';
 
   constructor(private servicio: SolicitudAduanaService) {}
 
-  protected formatearRut(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    let value = input.value.replace(/[^0-9kK]/g, '').toUpperCase();
-    if (value.length > 1) {
-      const cuerpo = value.slice(0, -1);
-      const dv = value.slice(-1);
-      let formatted = '';
-      for (let i = cuerpo.length - 1, j = 1; i >= 0; i--, j++) {
-        formatted = cuerpo.charAt(i) + formatted;
-        if (j % 3 === 0 && i !== 0) {
-          formatted = '.' + formatted;
-        }
-      }
-      formatted += '-' + dv;
-      input.value = formatted;
-    } else {
-      input.value = value;
-    }
-    this.rut = input.value;
-  }
-
   protected buscar(): void {
     this.errorMsg = '';
-    if (!esRutValido(this.rut)) {
+    const idNum = parseInt(this.id, 10);
+    if (isNaN(idNum) || idNum <= 0) {
       this.resultados = [];
-      this.errorMsg = 'Ingresa un RUT válido.';
+      this.errorMsg = 'Ingresa un ID válido.';
       return;
     }
-    this.servicio.obtenerPorRutMenor(this.rut).subscribe({
+    this.servicio.obtenerPorId(idNum).subscribe({
       next: (data) => {
-        this.resultados = data;
-        if (!data.length) {
-          this.errorMsg = 'No existen solicitudes para el RUT ingresado.';
+        this.resultados = [data];
+      },
+      error: (err) => {
+        this.resultados = [];
+        if (err.status === 404) {
+          this.errorMsg = 'No existe una solicitud con el ID ingresado.';
+        } else {
+          this.errorMsg = 'No se pudo obtener la información';
         }
       },
-      error: () => (this.errorMsg = 'No se pudo obtener la información'),
     });
   }
-}
-
-function esRutValido(value: string): boolean {
-  if (!value) {
-    return false;
-  }
-  const clean = value.replace(/\./g, '');
-  const rutPattern = /^[0-9]+-[0-9kK]{1}$/;
-  if (!rutPattern.test(clean)) {
-    return false;
-  }
-  const [num, dv] = clean.split('-');
-  let sum = 0;
-  let multiplier = 2;
-  for (let i = num.length - 1; i >= 0; i--) {
-    sum += parseInt(num.charAt(i), 10) * multiplier;
-    multiplier = multiplier === 7 ? 2 : multiplier + 1;
-  }
-  const expected = 11 - (sum % 11);
-  const dvCalc = expected === 11 ? '0' : expected === 10 ? 'K' : expected.toString();
-  return dvCalc.toUpperCase() === dv.toUpperCase();
 }

--- a/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -231,7 +231,7 @@ export class FormularioSolicitudComponent implements OnInit {
             'Creación de solicitud exitosa. \n' +
             'Se ha enviado un comprobante al correo \n' +
             f.emailPadre +
-            '. Para hacer seguimiento debe ir a la página principal e ingresar el rut del menor en la opción Seguimiento';
+            '. Para hacer seguimiento debe ir a la página principal e ingresar el ID de la solicitud en la opción Seguimiento';
           this.errorMsg = '';
           this.isSubmitting = false;
           this.cdr.detectChanges();

--- a/frontend/src/app/services/solicitudes-aduana/solicitud-aduana.ts
+++ b/frontend/src/app/services/solicitudes-aduana/solicitud-aduana.ts
@@ -51,4 +51,8 @@ export class SolicitudAduanaService {
     const params = new HttpParams().set('rut', rut);
     return this.http.get<SolicitudViajeMenor[]>(`${this.baseUrl}/menor`, { params });
   }
+
+  obtenerPorId(id: number): Observable<SolicitudViajeMenor> {
+    return this.http.get<SolicitudViajeMenor>(`${this.baseUrl}/${id}`);
+  }
 }


### PR DESCRIPTION
## Summary
- adjust backend service API to fetch solicitud by id
- search by id instead of rut in seguimiento component
- update tracking page markup for id search
- update success message after creating a solicitud

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw -q test` *(fails: network access needed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e24538ed08326950a477c5f6fa6e2