### PR TITLE
Show solicitud id on success

### DIFF
--- a/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
+++ b/backend/src/main/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaController.java
@@ -38,7 +38,7 @@ public class SolicitudAduanaController {
   }
 
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<Void> crearSolicitud(
+  public ResponseEntity<SolicitudViajeMenoresResponse> crearSolicitud(
       @ModelAttribute SolicitudViajeMenoresRequest request,
       @RequestPart(value = "archivos", required = false) List<MultipartFile> archivos,
       @RequestParam(value = "tiposDocumento", required = false) List<String> tiposDoc) {
@@ -89,7 +89,7 @@ public class SolicitudAduanaController {
         adjuntoService.guardarAdjuntos(creada, tiposRecibidos, archivosRecibidos);
       }
 
-      return ResponseEntity.ok().build();
+      return ResponseEntity.ok(mapearSolicitud(creada));
 
     } catch (Exception e) {
       return ResponseEntity.internalServerError().build();

--- a/backend/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
+++ b/backend/src/test/java/cl/duoc/sistema_aduanero/controller/SolicitudAduanaControllerTest.java
@@ -53,8 +53,9 @@ class SolicitudAduanaControllerTest {
                      .file(file1)
                      .file(file2)
                      .file(file3)
-        .param("estado", "NUEVA"))
-        .andExpect(status().isOk());
+                     .param("estado", "NUEVA"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(3));
   }
 
   @Test
@@ -71,7 +72,8 @@ class SolicitudAduanaControllerTest {
 
     mockMvc
         .perform(multipart("/api/solicitudes"))
-        .andExpect(status().isOk());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(4));
 
     ArgumentCaptor<SolicitudViajeMenores> captor =
         ArgumentCaptor.forClass(SolicitudViajeMenores.class);
@@ -92,7 +94,8 @@ class SolicitudAduanaControllerTest {
         .perform(multipart("/api/solicitudes")
                      .param("tipoSolicitudMenor", "Entrada")
                      .param("paisDestino", "Peru"))
-        .andExpect(status().isOk());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(5));
 
     ArgumentCaptor<SolicitudViajeMenores> captor =
         ArgumentCaptor.forClass(SolicitudViajeMenores.class);
@@ -113,7 +116,8 @@ class SolicitudAduanaControllerTest {
         .perform(multipart("/api/solicitudes")
                      .param("tipoSolicitudMenor", "Salida")
                      .param("paisOrigen", "Argentina"))
-        .andExpect(status().isOk());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(6));
 
     ArgumentCaptor<SolicitudViajeMenores> captor =
         ArgumentCaptor.forClass(SolicitudViajeMenores.class);

--- a/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
+++ b/frontend/src/app/pages/solicitudes-aduana/formulario-solicitud/formulario-solicitud.ts
@@ -226,9 +226,9 @@ export class FormularioSolicitudComponent implements OnInit {
     this.service
       .crearConAdjunto(payload, tipos, archivos)
       .subscribe({
-        next: () => {
+        next: (solicitud) => {
           this.successMsg =
-            'Creación de solicitud exitosa. \n' +
+            `Creación de solicitud exitosa. ID: ${solicitud.id}\n` +
             'Se ha enviado un comprobante al correo \n' +
             f.emailPadre +
             '. Para hacer seguimiento debe ir a la página principal e ingresar el ID de la solicitud en la opción Seguimiento';


### PR DESCRIPTION
## Summary
- return the created solicitud information from the backend
- display the ID in the success message
- test controller expects ID in the response

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685f3c9c039c8326ab13ed27f5e4c469